### PR TITLE
Fix card layout to display in a horizontal row

### DIFF
--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,5 +1,5 @@
 .grid {
-  display: gri;
+  display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1.5rem;
   padding: 1rem;

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -7,6 +7,7 @@ import { CommonModule } from '@angular/common';
 @Component({
   standalone: true,
   templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
   imports: [NgFor, AsyncPipe, ProductCardComponent, CommonModule]
 })
 export class HomeComponent {

--- a/src/app/ui/product-card/product-card.component.scss
+++ b/src/app/ui/product-card/product-card.component.scss
@@ -1,5 +1,5 @@
 :host {
-  display: contents;
+  display: block;
 }
 
 .card {


### PR DESCRIPTION
The product cards on the home page were not displaying in a horizontal row as intended. This was caused by a combination of three issues:

1. A typo in `src/app/pages/home/home.component.scss` where `display: grid` was misspelled as `display: gri`.
2. The `HomeComponent` in `src/app/pages/home/home.component.ts` was missing the `styleUrls` property, so the stylesheet was not being applied.
3. The `:host` of the `ProductCardComponent` in `src/app/ui/product-card/product-card.component.scss` was set to `display: contents`, which caused the component's host element to be ignored by the grid layout.

This commit corrects the typo, adds the `styleUrls` property to the `HomeComponent`, and sets the `:host` of the `ProductCardComponent` to `display: block`. These changes ensure that the grid layout is applied correctly and the product cards are displayed in a horizontal row.