### PR TITLE
feat: Implement Amazon SiteStripe on product cards

### DIFF
--- a/src/app/core/models/product.model.ts
+++ b/src/app/core/models/product.model.ts
@@ -4,4 +4,5 @@ export interface Product {
   price: number;
   image: string;
   description?: string;
+  amazonLink?: string;
 }

--- a/src/app/ui/product-card/product-card.component.html
+++ b/src/app/ui/product-card/product-card.component.html
@@ -3,5 +3,16 @@
   <h3>{{ product.name }}</h3>
   <p class="price">${{ product.price }}</p>
   <p class="desc">{{ product.description }}</p>
-  <button (click)="cart.add(product)">Add to cart</button>
+  <div class="buttons">
+    <button (click)="cart.add(product)">Add to cart</button>
+    <a
+      *ngIf="product.amazonLink"
+      [href]="product.amazonLink"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="amazon-link"
+    >
+      View on Amazon
+    </a>
+  </div>
 </div>

--- a/src/app/ui/product-card/product-card.component.scss
+++ b/src/app/ui/product-card/product-card.component.scss
@@ -44,7 +44,15 @@ h3 {
   margin-bottom: 1rem;
 }
 
-button {
+.buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+  justify-content: center;
+}
+
+button,
+a.amazon-link {
   padding: .6rem 1.2rem;
   border: none;
   border-radius: 999px;
@@ -53,8 +61,17 @@ button {
   color: white;
   font-weight: 600;
   transition: background-color 0.2s;
+  text-decoration: none;
 }
 
 button:hover {
   background-color: #0056b3;
+}
+
+a.amazon-link {
+  background-color: #ff9900;
+}
+
+a.amazon-link:hover {
+  background-color: #cc7a00;
 }

--- a/src/assets/products.json
+++ b/src/assets/products.json
@@ -4,41 +4,23 @@
     "name": "Classic Tee",
     "price": 20,
     "image": "https://picsum.photos/seed/tee/400/400",
-    "description": "100% cotton."
+    "description": "100% cotton.",
+    "amazonLink": "https://amazon.com"
   },
   {
     "id": 2,
     "name": "Cozy Hoodie",
     "price": 45,
     "image": "https://picsum.photos/seed/hoodie/400/400",
-    "description": "Fleece-lined warmth."
+    "description": "Fleece-lined warmth.",
+    "amazonLink": "https://amazon.com"
   },
   {
     "id": 3,
     "name": "Dad Cap",
     "price": 18,
     "image": "https://picsum.photos/seed/cap/400/400",
-    "description": "Adjustable strap."
-  },
-  {
-    "id": 3,
-    "name": "Dad Cap",
-    "price": 18,
-    "image": "https://picsum.photos/seed/cap/400/400",
-    "description": "Adjustable strap."
-  },
-  {
-    "id": 3,
-    "name": "Dad Cap",
-    "price": 18,
-    "image": "https://picsum.photos/seed/cap/400/400",
-    "description": "Adjustable strap."
-  },
-  {
-    "id": 3,
-    "name": "Dad Cap",
-    "price": 18,
-    "image": "https://picsum.photos/seed/cap/400/400",
-    "description": "Adjustable strap."
+    "description": "Adjustable strap.",
+    "amazonLink": "https://amazon.com"
   }
 ]


### PR DESCRIPTION
This commit implements the Amazon SiteStripe functionality by adding a "View on Amazon" button to the product cards.

- Updates the `Product` model to include an optional `amazonLink` property.
- Adds placeholder `amazonLink` data to the `products.json` file.
- Modifies the `ProductCardComponent` to display a "View on Amazon" button, which is a styled anchor tag that opens the link in a new tab.
- Removes duplicate product entries from `products.json`.