### PR TITLE
Fix Express API compilation and verify Twilio SMS integration

### DIFF
--- a/express-api/package-lock.json
+++ b/express-api/package-lock.json
@@ -1500,7 +1500,6 @@
       "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2903,7 +2902,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/express-api/src/index.ts
+++ b/express-api/src/index.ts
@@ -12,7 +12,7 @@ if (!stripeSecretKey) {
   throw new Error('STRIPE_SECRET_KEY environment variable is not set');
 }
 const stripe = new Stripe(stripeSecretKey, {
-  apiVersion: '2025-08-27.basil',
+  apiVersion: '2025-09-30.clover',
 });
 
 // Twilio Configuration
@@ -73,7 +73,7 @@ app.post('/api/checkout', async (req: Request, res: Response) => {
           currency: 'usd',
           product_data: productData,
           unit_amount: Math.round(item.price * 100),
-          tax_behavior: 'exclusive',
+          tax_behavior: 'exclusive' as Stripe.Checkout.SessionCreateParams.LineItem.PriceData.TaxBehavior,
         },
         quantity: item.qty,
       };


### PR DESCRIPTION
The user requested a check of the Twilio API integration to ensure SMS functionality. Upon investigation, I found that the `express-api` service was failing to compile due to a mismatch between the Stripe SDK version and the hardcoded API version, as well as a TypeScript type error. 

I fixed these compilation issues, allowing the server to start. I then verified the Twilio integration by running a test script against the `notify-amazon-click` endpoint, confirming that the application correctly attempts to use the Twilio client to send SMS messages when triggered. The `checkout` endpoint also contains similar logic to send SMS upon session creation. The SMS functionality depends on valid `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` environment variables.

---
*PR created automatically by Jules for task [701654615939532873](https://jules.google.com/task/701654615939532873) started by @glaelt16*